### PR TITLE
export node module as .mjs file

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ssr"
   ],
   "main": "node/index.js",
-  "module": "node/module.js",
+  "module": "node/module.mjs",
   "types": "src/node.d.ts",
   "esnext": "src/node.js",
   "unpkg": "hyperapp-render.min.js",
@@ -29,7 +29,7 @@
   },
   "exports": {
     "node": {
-      "import": "./node/module.js",
+      "import": "./node/module.mjs",
       "require": "./node/index.js"
     },
     "default": {

--- a/tools/build.js
+++ b/tools/build.js
@@ -35,7 +35,7 @@ const files = [
   },
   {
     input: 'dist/src/node.js',
-    output: 'dist/node/module.js',
+    output: 'dist/node/module.mjs',
     format: 'es',
   },
 ]


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [?] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

this outputs an mjs file instead of a js file to node/module.mjs

[@magic/core](https://github.com/magic/core) is using node 14.2.0 and mjs files without compilation, and, contrary to most build tools, nodejs is not capable to detect modules automagically when importing.

alternatively to this commit we could also set `"type": "module",` in package.json, but i would expect that to break some commonjs applications on older node versions.

**please note**: i do not have a commonjs application ready to test this in!

```
> @magic/core@0.0.74 build /media/j/data/dev/magic/core
> NODE_ENV=production src/bin.mjs build

/media/j/data/dev/magic/core/node_modules/hyperapp-render/node/module.js:3
import { Readable } from 'stream';
^^^^^^

SyntaxError: Cannot use import statement outside a module
...
```