### PR TITLE
Allow empty string text nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  pull_request:
+    branches:
+      - '*'
   push:
     branches:
       - '*'

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const voidElements = new Set([
 
 // credits to https://github.com/component/escape-html
 export function escapeHtml(value) {
+  if (value == null) return '';
   const str = '' + value
   if (typeof value === 'number') {
     // better performance for safe values

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -478,6 +478,28 @@ describe('renderToString(view, state, actions)', () => {
     expect(html).toBe('<div>foo bar baz</div>')
   })
 
+  it('should correctly render empty text nodes', () => {
+    const VNode = {
+      tag: 'div',
+      props: {},
+      key: null,
+      children: [
+        {
+          tag: '',
+          props: {},
+          key: null,
+          children: [],
+          type: 3,
+          node: null,
+        },
+      ],
+      type: 1,
+      node: null,
+    }
+    const html = renderToString(VNode)
+    expect(html).toBe('<div></div>')
+  })
+
   it('should support Hyperapp V2 lazy nodes', () => {
     const VNode = {
       lazy: {


### PR DESCRIPTION
Currently, if you try to render a node like this:
```js
text('')
```

It will actually render `undefined` 🤔 

It goes through this part of the code to get HTML escaped, however, because the `||` operator considers `''` a falsy value, it goes for `node.name` instead, which does not exist on a VDOM node. The first line in this `escapeHtml` function converts this `undefined` value to string, which ends up being the string `'undefined'`.

I think this is a bug?

Hope this helps!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have read the **CONTRIBUTING** document.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
